### PR TITLE
Provide AndroidTV support

### DIFF
--- a/common/device-common.mk
+++ b/common/device-common.mk
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ifneq (,$(filter $(TARGET_PRODUCT),hikey960_tv hikey_tv))
+ifneq (,$(filter $(DEVICE_TYPE),tv))
 # Setup TV Build
 USE_OEM_TV_APP := true
 $(call inherit-product, device/google/atv/products/atv_base.mk)
@@ -30,7 +30,7 @@ PRODUCT_SHIPPING_API_LEVEL := 29
 
 # Set custom settings
 DEVICE_PACKAGE_OVERLAYS := device/linaro/hikey/overlay
-ifneq (,$(filter $(TARGET_PRODUCT),hikey960_tv hikey_tv))
+ifneq (,$(filter $(DEVICE_TYPE),tv))
 # Set TV Custom Settings
 DEVICE_PACKAGE_OVERLAYS += device/google/atv/overlay
 endif
@@ -125,7 +125,7 @@ PRODUCT_PACKAGES += \
     android.hardware.health@2.0-service \
     android.hardware.health@2.0-impl-default \
 
-ifneq (,$(filter $(TARGET_PRODUCT),hikey960_tv hikey_tv))
+ifneq (,$(filter $(DEVICE_TYPE),tv))
 # TV Specific Packages
 PRODUCT_PACKAGES += \
     TvSettings \

--- a/common/device-common.mk
+++ b/common/device-common.mk
@@ -191,6 +191,13 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PACKAGES += \
     FDroid \
 
+# Prebuild .apk applications for Android TV
+ifneq (,$(filter $(DEVICE_TYPE),tv))
+PRODUCT_PACKAGES += \
+    Kodi \
+
+endif
+
 # Recovery
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/init.recovery.glodroid.rc:recovery/root/init.recovery.$(TARGET_PRODUCT).rc \


### PR DESCRIPTION
Add the plus2e_tv.mk product makefile, and lunch choice for AndroidTV.
Change the nessesary a target product value to build AndroidTV on
the plus2e_tv value.

Console commands for building AndroidTV:
```
export DEVICE_TYPE=tv
source ./build/envsetup.sh
lunch plus2e_tv-userdebug
make sdcard
```