### PR TITLE
Fix cross compiler for M0 of rockchip

### DIFF
--- a/platform/atf.mk
+++ b/platform/atf.mk
@@ -13,8 +13,10 @@ LOCAL_PATH := $(call my-dir)
 ATF_SRC		:= external/arm-trusted-firmware
 
 #-------------------------------------------------------------------------------
+M0_TRIPLE := arm-eabi
+M0_COMPILE := M0_CROSS_COMPILE=$$(readlink -f prebuilts/gcc/linux-x86/arm/gcc-linaro-$(M0_TRIPLE)/bin/$(M0_TRIPLE)-)
 
 $(ATF_BINARY): $(sort $(shell find -L $(ATF_SRC)))
-	$(MAKE_COMMON) -C $(ATF_SRC) BUILD_BASE=$$(readlink -f $(ATF_OUT)) PLAT=$(ATF_PLAT) DEBUG=1 bl31
+	$(M0_COMPILE) $(MAKE_COMMON) -C $(ATF_SRC) BUILD_BASE=$$(readlink -f $(ATF_OUT)) PLAT=$(ATF_PLAT) DEBUG=1 bl31
 
 endif


### PR DESCRIPTION
M0 needs to arm-eabi for compiling atf of rockchip rk3399.

Signed-off-by: Daniil Petrov <daniil.petrov@globallogic.com>