### PR TITLE
Add OrangePI PC+ target

### DIFF
--- a/opi_pc_plus/AndroidProducts.mk
+++ b/opi_pc_plus/AndroidProducts.mk
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2019 The Android Open-Source Project
+# Copyright (C) 2021 GloDroid project
+
+PRODUCT_MAKEFILES := \
+    $(LOCAL_DIR)/opi_pc_plus.mk
+
+COMMON_LUNCH_CHOICES := \
+    opi_pc_plus-userdebug

--- a/opi_pc_plus/BoardConfig.mk
+++ b/opi_pc_plus/BoardConfig.mk
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2019 The Android Open-Source Project
+# Copyright (C) 2021 GloDroid project
+
+include device/glodroid/common/boardconfig-common.mk
+
+# Architecture
+TARGET_ARCH := arm
+TARGET_ARCH_VARIANT := armv7-a-neon
+#TARGET_CPU_VARIANT := cortex-a7
+TARGET_CPU_VARIANT := generic
+TARGET_CPU_ABI := armeabi-v7a
+TARGET_CPU_ABI2 := armeabi
+
+TARGET_SUPPORTS_32_BIT_APPS := true
+TARGET_SUPPORTS_64_BIT_APPS := false
+
+TARGET_BOARD_INFO_FILE := device/glodroid/opi_pc_plus/board-info.txt

--- a/opi_pc_plus/audio.opi_pc_plus.xml
+++ b/opi_pc_plus/audio.opi_pc_plus.xml
@@ -1,0 +1,16 @@
+<audiohal>
+    <mixer card="0">
+        <init>
+            <ctl name="Line Out Playback Volume" val="31" />
+            <ctl name="Line Out Playback Switch" val="1"/>
+            <ctl name="DAC Playback Switch" val="1"/>
+            <ctl name="Mic1 Capture Switch" val="1"/>
+        </init>
+    </mixer>
+
+    <stream type="pcm" dir="out" card="0" device="0" rate="48000">
+    </stream>
+
+    <stream type="pcm" dir="in" card="0" device="0" rate="48000">
+    </stream>
+</audiohal>

--- a/opi_pc_plus/board-info.txt
+++ b/opi_pc_plus/board-info.txt
@@ -1,0 +1,1 @@
+require board=opi_pc_plus

--- a/opi_pc_plus/device.mk
+++ b/opi_pc_plus/device.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2021 GloDroid project
+
+$(call inherit-product, device/glodroid/common/lowram/device-common-1gb.mk)
+$(call inherit-product, device/glodroid/common/device-common-sunxi.mk)
+$(call inherit-product, device/glodroid/common/bluetooth/no-bluetooth.mk)
+
+# Out-of-tree modules
+PRODUCT_PACKAGES += \
+    8189fs.ko \
+
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/audio.opi_pc_plus.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio.opi_pc_plus.xml \
+
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/wifi.opi_pc_plus.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/wifi.opi_pc_plus.rc \

--- a/opi_pc_plus/opi_pc_plus.mk
+++ b/opi_pc_plus/opi_pc_plus.mk
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2021 GloDroid project
+
+$(call inherit-product, device/glodroid/opi_pc_plus/device.mk)
+
+PRODUCT_BOARD_PLATFORM := sunxi
+PRODUCT_NAME := opi_pc_plus
+PRODUCT_DEVICE := opi_pc_plus
+PRODUCT_BRAND := OrangePI
+PRODUCT_MODEL := opi_pc_plus
+PRODUCT_MANUFACTURER := xunlong
+PRODUCT_HAS_EMMC := true
+
+UBOOT_DEFCONFIG := orangepi_pc_plus_defconfig
+KERNEL_SRC       := kernel/glodroid-stable
+KERNEL_DEFCONFIG := $(KERNEL_SRC)/arch/arm/configs/sunxi_defconfig
+KERNEL_FRAGMENTS += \
+    device/glodroid/platform/common/sunxi/sunxi-common.config \
+
+KERNEL_DTB_FILE := sun8i-h3-orangepi-pc-plus.dtb

--- a/opi_pc_plus/wifi.opi_pc_plus.rc
+++ b/opi_pc_plus/wifi.opi_pc_plus.rc
@@ -1,0 +1,3 @@
+on early-init
+    exec u:r:vendor_modprobe:s0 -- /vendor/bin/modprobe -d /vendor/lib/modules -a cfg80211
+    insmod /vendor/lib/modules/8189fs.ko


### PR DESCRIPTION
Based on Orange Pi Plus 2E configuration with some modifications.
Audio options have been changed.
Includes fix wifi.