### PR TITLE
Fix wifi connection on OrangePi Plus 2E

### DIFF
--- a/opi_plus2/wifi.plus2.rc
+++ b/opi_plus2/wifi.plus2.rc
@@ -1,2 +1,3 @@
 on early-init
+    exec u:r:vendor_modprobe:s0 -- /vendor/bin/modprobe -d /vendor/lib/modules -a cfg80211
     insmod /vendor/lib/modules/8189es.ko

--- a/opi_plus2e/init.opi_plus2e.aux.rc
+++ b/opi_plus2e/init.opi_plus2e.aux.rc
@@ -1,2 +1,3 @@
 on early-init
+    exec u:r:vendor_modprobe:s0 -- /vendor/bin/modprobe -d /vendor/lib/modules -a cfg80211
     insmod /vendor/lib/modules/8189fs.ko


### PR DESCRIPTION
The module cfg80211 was not loaded on startup.