### PR TITLE
pinephone: GSM audio enabling

### DIFF
--- a/pinephone/audio.pinephone.xml
+++ b/pinephone/audio.pinephone.xml
@@ -1,15 +1,30 @@
 <audiohal>
     <mixer name="PinePhone">
         <init>
-            <ctl name="AIF1 DA0 Playback Volume" val="160" />
-            <ctl name="DAC Playback Volume" val="160" />
-            <ctl name="Line Out Playback Volume" val="15" />
+            <!-- AIF1 Digital input (SoC) -->
+
+            <!-- Enable AIF1 I2S/PCM slot 0 to mixer source -->
             <ctl name="AIF1 Slot 0 Digital DAC Playback Switch" val="1"/>
+            <!-- Default Digital-to-analog digital playback volume -->
+            <ctl name="AIF1 DA0 Playback Volume" val="160" />
+
+            <!-- Digital-to-analog converter (DAC) -->
+
+            <!-- Enable DAC -->
             <ctl name="DAC Playback Switch" val="1"/>
+            <!-- Default DAC volume -->
+            <ctl name="DAC Playback Volume" val="160" />
+
+            <!-- Loudspeaker -->
+
+            <!-- Loudspeaker mono playback route  -->
             <ctl name="Line Out Source Playback Route" val="Mono Differential"/>
+            <!-- Default loudspeaker volume -->
+            <ctl name="Line Out Playback Volume" val="15" />
         </init>
     </mixer>
 
+    <!-- AUDIO_DEVICE_OUT_SPEAKER -->
     <device name="speaker">
         <path name="on">
             <ctl name="Line Out Playback Switch" val="1"/>

--- a/pinephone/audio.pinephone.xml
+++ b/pinephone/audio.pinephone.xml
@@ -8,6 +8,26 @@
             <!-- Default Digital-to-analog digital playback volume -->
             <ctl name="AIF1 DA0 Playback Volume" val="160" />
 
+            <!-- AIF2 Digital input (modem) -->
+
+            <!-- Default modem playback volume -->
+            <ctl name="AIF2 DAC Playback Volume" val="160"/>
+            <!-- AIF2 to DAC mono playback -->
+            <ctl name="AIF2 DAC Stereo Playback Route" val="Sum Mono"/>
+            <!-- From modem to DAC switch -->
+            <ctl name="AIF2 Digital DAC Playback Switch" val="1"/>
+
+            <!-- AIF2 Digital output (modem) -->
+
+            <!-- Default ADC to AIF2 volume -->
+            <ctl name="AIF2 ADC Capture Volume" val="160"/>
+            <!-- ADC to AIF2 mono playback route -->
+            <ctl name="AIF2 ADC Stereo Capture Route" val="Mix Mono"/>
+            <!-- Enable AIF1 source to modem switch -->
+            <ctl name="AIF2 ADC Mixer AIF1 DA0 Capture Switch" val="1"/>
+            <!-- From ADC to modem switch -->
+            <ctl name="AIF2 ADC Mixer ADC Capture Switch" val="1"/>
+
             <!-- Digital-to-analog converter (DAC) -->
 
             <!-- Enable DAC -->
@@ -15,12 +35,26 @@
             <!-- Default DAC volume -->
             <ctl name="DAC Playback Volume" val="160" />
 
+            <!-- Analog-to-digital converter (ADC) -->
+
+            <!-- Default ADC Gain Volume -->
+            <ctl name="ADC Gain Capture Volume" val="7"/>
+            <!-- Default ADC Capture Volume -->
+            <ctl name="ADC Capture Volume" val="160"/>
+
             <!-- Loudspeaker -->
 
             <!-- Loudspeaker mono playback route  -->
             <ctl name="Line Out Source Playback Route" val="Mono Differential"/>
             <!-- Default loudspeaker volume -->
             <ctl name="Line Out Playback Volume" val="30" />
+
+            <!-- Microphone -->
+
+            <!-- Default microphone HW boost volume -->
+            <ctl name="Mic1 Boost Volume" val="1"/>
+            <!-- Enable microphone by default -->
+            <ctl name="Mic1 Capture Switch" val="1"/>
         </init>
     </mixer>
 

--- a/pinephone/audio.pinephone.xml
+++ b/pinephone/audio.pinephone.xml
@@ -20,7 +20,7 @@
             <!-- Loudspeaker mono playback route  -->
             <ctl name="Line Out Source Playback Route" val="Mono Differential"/>
             <!-- Default loudspeaker volume -->
-            <ctl name="Line Out Playback Volume" val="15" />
+            <ctl name="Line Out Playback Volume" val="30" />
         </init>
     </mixer>
 


### PR DESCRIPTION
The initial configuration supports only one route:
    
    AIF1 (Advanced Peripheral Bus) <--> Line Out (Loudspeaker)
    
Add 4 additional initial routes:
    
    AIF1 <--> Mic1 (Internal microphone)
    AIF1 <--> AIF2 (Baseband)
    AIF2 <--> DAC (Digital-to-analog converter)
    AIF2 <--> Mic1