### PR TITLE
common: fix vbmeta partition typo

### DIFF
--- a/common/base/board.mk
+++ b/common/base/board.mk
@@ -107,7 +107,7 @@ BOARD_GLODROID_DYNAMIC_PARTITIONS_SIZE := $(shell echo $$(( $(BOARD_SUPER_PARTIT
 BOARD_GLODROID_DYNAMIC_PARTITIONS_PARTITION_LIST := system system_ext vendor product vendor_dlkm
 
 AB_OTA_UPDATER := true
-AB_OTA_PARTITIONS += boot system system_ext vendor product vendor_dlkm vendor_boot vbmeta vmbeta_system
+AB_OTA_PARTITIONS += boot system system_ext vendor product vendor_dlkm vendor_boot vbmeta vbmeta_system
 
 TARGET_RECOVERY_PIXEL_FORMAT := RGBX_8888
 


### PR DESCRIPTION
vbmeta_system partition was not being built correctly due to typo in AB_OTA_PARTITIONS.